### PR TITLE
Fixed command injection bug in last-commit-log

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = class LCL {
       '%at', '%ar', '%an', '%ae',
     ];
     const splitCharacter = '<#__last-commit-log__#>';
-    const command = `git ${this.gitDirStr} log -1 --pretty=format:"` + prettyFormat.join(splitCharacter) + '"';
+    const command = [this.gitDirStr, 'log', '-1', '--pretty-format:"', prettyFormat.join(splitCharacter), '"'];
 
     let c;
     let gitRemote;
@@ -33,8 +33,7 @@ module.exports = class LCL {
         cwd: this.cwd,
         maxBuffer: 1024 * 1024 * 1024,
       };
-      var args = command.split(' ');
-      const stdout = execFileSync('git', args.slice(1), opts).toString();
+      const stdout = execFileSync('git', command, opts).toString();
       c = stdout.split(splitCharacter);
       gitBranch = getGitBranch({
         gitDirStr: this.gitDirStr,
@@ -42,7 +41,8 @@ module.exports = class LCL {
       }, {
         shortHash: c[0],
       });
-      const tag = execSync(`git ${this.gitDirStr} tag --contains HEAD`, opts).toString();
+      args = [this.gitDirStr, 'tag', '--contains', 'HEAD'];
+      const tag = execFileSync('git', args, opts).toString();
       gitTag = tag.trim();
       const config = dotgitconfig(this.cwd);
       gitRemote = config.remote && config.remote.origin && config.remote.origin.url;
@@ -97,9 +97,14 @@ module.exports = class LCL {
 function getGitBranch(opts = {}, { shortHash }) {
   let _branch = '';
 
-  const revParseBranch = execSync(`git ${opts.gitDirStr} rev-parse --abbrev-ref HEAD`, opts).toString();
-  const nameRevBranch = execSync(`git ${opts.gitDirStr} name-rev --name-only HEAD`, opts).toString();
-  const gitLogBranch = execSync(`git ${opts.gitDirStr} log -n 1 --pretty=%d HEAD`, opts).toString();
+  var args = [opts.gitDirStr, 'rev-parse', '--abbrev-ref', 'HEAD'];
+  const revParseBranch = execFileSync('git', args, opts).toString();
+
+  args = [opts.gitDirStr, 'name-rev', '--name-only', 'HEAD'];
+  const nameRevBranch = execFileSync('git', args, opts).toString();
+
+  args = [opts.gitDirStr, 'log', '-n' , '1', '--pretty=%d', 'HEAD'];
+  const gitLogBranch = execFileSync('git', args, opts).toString();
 
   const branchRP = revParseBranch.trim();
   const branchNR = nameRevBranch.trim()

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const url = require('url');
 const dotgitconfig = require('dotgitconfig');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 module.exports = class LCL {
   constructor(dir = process.cwd()) {
@@ -33,7 +33,8 @@ module.exports = class LCL {
         cwd: this.cwd,
         maxBuffer: 1024 * 1024 * 1024,
       };
-      const stdout = execSync(command, opts).toString();
+      var args = command.split(' ');
+      const stdout = execFileSync('git', args.slice(1), opts).toString();
       c = stdout.split(splitCharacter);
       gitBranch = getGitBranch({
         gitDirStr: this.gitDirStr,


### PR DESCRIPTION
### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-last-commit-log

### ⚙️ Description *

last-commit-log is vulnerable to OS Command Injection since a command is crafted using user inputs not validated and then executed, leading to arbitrary command injection. The argument options can be controlled by users without any sanitization. It was using `execSync()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `execSync()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFileSync()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package, export GIT_DIR and run the below code,:
```javascript
// poc.js
const LCL = require('last-commit-log');
const lcl = new LCL('.');
lcl
.getLastCommit()
.then(commit => console.log(commit));
```
* Export malicious `GIT_DIR` string `export GIT_DIR=". ;touch vulnerable;"`
* Run the poc.js and a file named `vulnerable` will be created in the current working directory.

![image](https://user-images.githubusercontent.com/16708391/102105870-ea5c6c80-3e55-11eb-899b-f1a8738a2631.png)


### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

![image](https://user-images.githubusercontent.com/16708391/102106063-2394dc80-3e56-11eb-9898-89570fd95b48.png)


### 👍 User Acceptance Testing (UAT)

Only `execFileSync` is used, no breaking changes introduced.
